### PR TITLE
Added support for SendDtmf and Pause BXML verbs

### DIFF
--- a/src/main/java/com/bandwidth/sdk/xml/Response.java
+++ b/src/main/java/com/bandwidth/sdk/xml/Response.java
@@ -32,7 +32,8 @@ public class Response {
         for (Elements verb : verbList) {
             try {
                 JAXBContext jc = JAXBContext.newInstance(Hangup.class, Transfer.class, SpeakSentence.class,
-                        PlayAudio.class, Redirect.class, SendMessage.class, Gather.class, Record.class);
+                        PlayAudio.class, Redirect.class, SendMessage.class, Gather.class, Record.class,
+                        SendDtmf.class, Pause.class);
                 Marshaller marshaller = jc.createMarshaller();
                 marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
                 marshaller.setProperty(Marshaller.JAXB_FRAGMENT, true);

--- a/src/main/java/com/bandwidth/sdk/xml/elements/Pause.java
+++ b/src/main/java/com/bandwidth/sdk/xml/elements/Pause.java
@@ -1,0 +1,38 @@
+package com.bandwidth.sdk.xml.elements;
+
+import com.bandwidth.sdk.exception.XMLInvalidAttributeException;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "Pause")
+public class Pause implements Elements {
+
+    private int length;
+
+    public Pause() {
+    }
+
+    public Pause(int length) throws XMLInvalidAttributeException {
+        setLength(length);
+    }
+
+    @XmlAttribute(name = "length")
+    public int getLength() {
+        return length;
+    }
+
+    public void setLength(int length) throws XMLInvalidAttributeException {
+        if (0 > length || length > 3600) {
+            throw new XMLInvalidAttributeException("'length' must be between 0 and 3600 inclusive");
+        }
+        this.length = length;
+    }
+
+    @Override
+    public String toString() {
+        return "Pause{" +
+                "length='" + length + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/com/bandwidth/sdk/xml/elements/SendDtmf.java
+++ b/src/main/java/com/bandwidth/sdk/xml/elements/SendDtmf.java
@@ -1,0 +1,39 @@
+package com.bandwidth.sdk.xml.elements;
+
+import com.bandwidth.sdk.exception.XMLInvalidTagContentException;
+
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlValue;
+
+@XmlRootElement(name = "SendDtmf")
+public class SendDtmf implements Elements {
+
+    private String value;
+
+    public SendDtmf() {
+    }
+
+    public SendDtmf(String value) throws XMLInvalidTagContentException {
+        setValue(value);
+    }
+
+    @XmlValue
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) throws XMLInvalidTagContentException {
+        if (value == null || !value.matches("[,wW\\d\\*#]{1,92}")) {
+            throw new XMLInvalidTagContentException("'value' contains invalid characters or wrong length");
+        }
+
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return "SendDtmf{" +
+                "value='" + value + '\'' +
+                '}';
+    }
+}

--- a/src/test/java/com/bandwidth/sdk/xml/TestResponse.java
+++ b/src/test/java/com/bandwidth/sdk/xml/TestResponse.java
@@ -7,6 +7,7 @@ import com.bandwidth.sdk.xml.elements.*;
 import junit.framework.Assert;
 import junit.framework.AssertionFailedError;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.custommonkey.xmlunit.DetailedDiff;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.junit.Test;
@@ -469,6 +470,61 @@ public class TestResponse {
     public void testRecord_InvalidCase_SpaceTranscribeCallbackUrl() throws IOException, XMLMarshallingException, XMLInvalidAttributeException, ParserConfigurationException, SAXException {
         Record record = new Record();
         record.setTranscribeCallbackUrl(" ");
+    }
+
+    @Test
+    public void testPause() throws XMLInvalidAttributeException, XMLMarshallingException, IOException, ParserConfigurationException, SAXException {
+        Pause pause = new Pause(42);
+
+        Response response = new Response();
+        response.add(pause);
+
+        String output = response.toXml();
+        String xmlReference = IOUtils.toString(getClass().getResourceAsStream("/pause.xml"), "UTF-8");
+        compareXML(xmlReference, output);
+    }
+
+    @Test(expected = XMLInvalidAttributeException.class)
+    public void testPause_InvalidCase_NegativeOne() throws XMLInvalidAttributeException {
+        new Pause(-1);
+    }
+
+    @Test(expected = XMLInvalidAttributeException.class)
+    public void testPause_InvalidCase_3601() throws XMLInvalidAttributeException {
+        new Pause(3601);
+    }
+
+    @Test
+    public void testSendDtmf() throws XMLMarshallingException, IOException, ParserConfigurationException, SAXException, XMLInvalidTagContentException {
+        SendDtmf sendDtmf = new SendDtmf("WW42");
+
+        Response response = new Response();
+        response.add(sendDtmf);
+
+        String output = response.toXml();
+        String xmlReference = IOUtils.toString(getClass().getResourceAsStream("/sendDtmf.xml"), "UTF-8");
+        compareXML(xmlReference, output);
+    }
+
+    @Test(expected = XMLInvalidTagContentException.class)
+    public void testSendDtmf_IsValid_InvalidCase_Null() throws XMLInvalidTagContentException {
+        new SendDtmf(null);
+    }
+
+    @Test(expected = XMLInvalidTagContentException.class)
+    public void testSendDtmf_IsValid_InvalidCase_Empty() throws XMLInvalidTagContentException {
+        new SendDtmf("");
+    }
+
+    @Test(expected = XMLInvalidTagContentException.class)
+    public void testSendDtmf_IsValid_InvalidCase_UnsupportedCharacters() throws XMLInvalidTagContentException {
+        new SendDtmf("invalid");
+    }
+
+    @Test(expected = XMLInvalidTagContentException.class)
+    public void testSendDtmf_IsValid_InvalidCase_TooLong() throws XMLInvalidTagContentException {
+        String tooLong = StringUtils.rightPad("W", 93, 'W');
+        new SendDtmf(tooLong);
     }
 
     private void compareXML (String expected, String current) throws ParserConfigurationException, IOException, SAXException {

--- a/src/test/resources/pause.xml
+++ b/src/test/resources/pause.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+    <Pause length="42"/>
+</Response>

--- a/src/test/resources/sendDtmf.xml
+++ b/src/test/resources/sendDtmf.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+    <SendDtmf>WW42</SendDtmf>
+</Response>


### PR DESCRIPTION
As mentioned in issue #47, the BXML verbs SendDtmf and Pause were missing--this adds them. I tried my best to keep the same formatting of what's already in here. Let me know what you think.

 - Tim